### PR TITLE
feat: 对话历史保存与管理 / Conversation History Persistence

### DIFF
--- a/frontend/src/components/ConversationSidebar.tsx
+++ b/frontend/src/components/ConversationSidebar.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react'
+import { Plus, Trash2, MessageSquare } from 'lucide-react'
+
+export interface ConversationSummary {
+  id: string
+  title: string
+  domain: string
+  message_count: number
+  created_at: string
+  updated_at: string
+}
+
+interface Props {
+  conversations: ConversationSummary[]
+  activeId: string | null
+  onSelect: (id: string) => void
+  onNew: () => void
+  onDelete: (id: string) => void
+}
+
+export default function ConversationSidebar({
+  conversations,
+  activeId,
+  onSelect,
+  onNew,
+  onDelete,
+}: Props) {
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
+
+  const formatTime = (iso: string) => {
+    const d = new Date(iso)
+    const now = new Date()
+    const diffMs = now.getTime() - d.getTime()
+    const diffMin = Math.floor(diffMs / 60000)
+    if (diffMin < 1) return '刚刚'
+    if (diffMin < 60) return `${diffMin} 分钟前`
+    const diffHour = Math.floor(diffMin / 60)
+    if (diffHour < 24) return `${diffHour} 小时前`
+    const diffDay = Math.floor(diffHour / 24)
+    if (diffDay < 7) return `${diffDay} 天前`
+    return d.toLocaleDateString()
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* New conversation button */}
+      <div className="p-3">
+        <button
+          onClick={onNew}
+          className="flex items-center gap-2 w-full px-3 py-2.5 bg-primary-600 hover:bg-primary-700 text-white rounded-lg transition-colors text-sm font-medium"
+        >
+          <Plus className="w-4 h-4" />
+          新建对话
+        </button>
+      </div>
+
+      {/* Conversation list */}
+      <div className="flex-1 overflow-y-auto px-3 pb-3 space-y-1">
+        {conversations.length === 0 ? (
+          <div className="text-center py-8 text-dark-500 text-sm">
+            暂无对话记录
+          </div>
+        ) : (
+          conversations.map((conv) => (
+            <div
+              key={conv.id}
+              className={`group flex items-center gap-2 px-3 py-2.5 rounded-lg cursor-pointer transition-colors ${
+                activeId === conv.id
+                  ? 'bg-primary-600/15 text-primary-400'
+                  : 'text-dark-300 hover:bg-dark-800'
+              }`}
+              onClick={() => onSelect(conv.id)}
+              onMouseEnter={() => setHoveredId(conv.id)}
+              onMouseLeave={() => setHoveredId(null)}
+            >
+              <MessageSquare className="w-4 h-4 flex-shrink-0 opacity-50" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm truncate">{conv.title}</p>
+                <p className="text-xs text-dark-500 truncate">
+                  {formatTime(conv.updated_at)}
+                </p>
+              </div>
+              {hoveredId === conv.id && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onDelete(conv.id)
+                  }}
+                  className="p-1 rounded hover:bg-dark-700 text-dark-500 hover:text-red-400 transition-colors"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,9 +1,12 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { Send, Loader2, Settings2, Trash2 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import DomainSelector from '../components/DomainSelector'
+import ConversationSidebar, {
+  type ConversationSummary,
+} from '../components/ConversationSidebar'
 
 interface Message {
   id: string
@@ -32,6 +35,10 @@ export default function ChatPage() {
   const [showSettings, setShowSettings] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
 
+  // Conversation state
+  const [conversations, setConversations] = useState<ConversationSummary[]>([])
+  const [activeConvId, setActiveConvId] = useState<string | null>(null)
+
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }
@@ -39,6 +46,112 @@ export default function ChatPage() {
   useEffect(() => {
     scrollToBottom()
   }, [messages])
+
+  // Load conversation list on mount
+  useEffect(() => {
+    fetchConversations()
+  }, [])
+
+  const fetchConversations = async () => {
+    try {
+      const res = await fetch('/api/v1/conversations/')
+      if (res.ok) {
+        const data = await res.json()
+        setConversations(data)
+      }
+    } catch {
+      // Ignore — Redis may not be available
+    }
+  }
+
+  const loadConversation = async (convId: string) => {
+    try {
+      const res = await fetch(`/api/v1/conversations/${convId}`)
+      if (res.ok) {
+        const conv = await res.json()
+        setActiveConvId(conv.id)
+        setDomain(conv.domain)
+        setMessages(
+          conv.messages.map((m: { id: string; role: string; content: string; timestamp: string }) => ({
+            ...m,
+            timestamp: new Date(m.timestamp),
+          }))
+        )
+      }
+    } catch {
+      // Ignore
+    }
+  }
+
+  const saveConversation = useCallback(
+    async (msgs: Message[], convDomain: string, convId: string | null) => {
+      const serialized = msgs.map((m) => ({
+        id: m.id,
+        role: m.role,
+        content: m.content,
+        timestamp: m.timestamp instanceof Date ? m.timestamp.toISOString() : m.timestamp,
+      }))
+
+      try {
+        if (convId) {
+          // Update existing
+          const title =
+            msgs.find((m) => m.role === 'user')?.content.slice(0, 30) || '新对话'
+          await fetch(`/api/v1/conversations/${convId}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              title,
+              domain: convDomain,
+              messages: serialized,
+            }),
+          })
+        } else {
+          // Create new
+          const title =
+            msgs.find((m) => m.role === 'user')?.content.slice(0, 30) || '新对话'
+          const res = await fetch('/api/v1/conversations/', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ title, domain: convDomain }),
+          })
+          if (res.ok) {
+            const conv = await res.json()
+            setActiveConvId(conv.id)
+            // Save messages into newly created conversation
+            await fetch(`/api/v1/conversations/${conv.id}`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ messages: serialized }),
+            })
+          }
+        }
+        await fetchConversations()
+      } catch {
+        // Ignore save errors
+      }
+    },
+    []
+  )
+
+  const handleNewConversation = () => {
+    setActiveConvId(null)
+    setMessages([])
+    setDomain('general')
+  }
+
+  const handleDeleteConversation = async (convId: string) => {
+    try {
+      await fetch(`/api/v1/conversations/${convId}`, { method: 'DELETE' })
+      if (activeConvId === convId) {
+        setActiveConvId(null)
+        setMessages([])
+      }
+      await fetchConversations()
+    } catch {
+      // Ignore
+    }
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -129,15 +242,37 @@ export default function ChatPage() {
       ])
     } finally {
       setIsLoading(false)
+      // Auto-save after response completes
+      setMessages((latestMsgs) => {
+        saveConversation(latestMsgs, domain, activeConvId)
+        return latestMsgs
+      })
     }
   }
 
   const clearChat = () => {
+    if (activeConvId) {
+      handleDeleteConversation(activeConvId)
+    }
     setMessages([])
+    setActiveConvId(null)
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex h-full">
+      {/* Conversation history sidebar */}
+      <div className="hidden md:flex w-64 flex-shrink-0 border-r border-dark-800 bg-dark-900/50 flex-col">
+        <ConversationSidebar
+          conversations={conversations}
+          activeId={activeConvId}
+          onSelect={loadConversation}
+          onNew={handleNewConversation}
+          onDelete={handleDeleteConversation}
+        />
+      </div>
+
+      {/* Chat area */}
+      <div className="flex flex-col flex-1 min-w-0">
       {/* Header */}
       <header className="flex items-center justify-between px-6 py-4 border-b border-dark-800">
         <div>
@@ -224,14 +359,14 @@ export default function ChatPage() {
                   <div className="prose prose-invert prose-sm max-w-none">
                     <ReactMarkdown
                       components={{
-                        code({ inline, className, children, ...props }) {
+                        code({ className, children, ...props }) {
                           const match = /language-(\w+)/.exec(className || '')
-                          return !inline && match ? (
+                          const isInline = !match
+                          return !isInline && match ? (
                             <SyntaxHighlighter
-                              style={oneDark}
+                              style={oneDark as Record<string, React.CSSProperties>}
                               language={match[1]}
                               PreTag="div"
-                              {...props}
                             >
                               {String(children).replace(/\n$/, '')}
                             </SyntaxHighlighter>
@@ -299,6 +434,7 @@ export default function ChatPage() {
           </button>
         </div>
       </form>
+    </div>
     </div>
   )
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "aiofiles>=23.2.0",
     "python-multipart>=0.0.6",
     "sse-starlette>=1.8.0",
+    "redis>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/server/api/v1/__init__.py
+++ b/server/api/v1/__init__.py
@@ -7,6 +7,7 @@ from .generate import router as generate_router
 from .mesh import router as mesh_router
 from .chat import router as chat_router
 from .knowledge import router as knowledge_router
+from .conversations import router as conversations_router
 
 router = APIRouter()
 
@@ -15,3 +16,4 @@ router.include_router(generate_router, prefix="/generate", tags=["Generate"])
 router.include_router(mesh_router, prefix="/mesh", tags=["Mesh"])
 router.include_router(chat_router, prefix="/chat", tags=["Chat"])
 router.include_router(knowledge_router, prefix="/knowledge", tags=["Knowledge"])
+router.include_router(conversations_router, prefix="/conversations", tags=["Conversations"])

--- a/server/api/v1/conversations.py
+++ b/server/api/v1/conversations.py
@@ -1,0 +1,165 @@
+"""Conversation history API endpoints with Redis persistence."""
+
+import json
+import uuid
+from datetime import datetime
+from typing import Optional, List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+import redis.asyncio as redis
+
+from ...core.config import settings
+
+router = APIRouter()
+
+# Redis connection pool
+_redis_pool: Optional[redis.Redis] = None
+
+CONV_PREFIX = "conv:"
+CONV_LIST_KEY = "conversations"
+
+
+async def get_redis() -> redis.Redis:
+    """Get or create Redis connection."""
+    global _redis_pool
+    if _redis_pool is None:
+        _redis_pool = redis.from_url(
+            settings.REDIS_URL,
+            decode_responses=True,
+        )
+    return _redis_pool
+
+
+class MessageItem(BaseModel):
+    """A single message in a conversation."""
+    id: str
+    role: str
+    content: str
+    timestamp: str
+
+
+class ConversationCreate(BaseModel):
+    """Request to create a conversation."""
+    title: Optional[str] = None
+    domain: str = "general"
+
+
+class ConversationUpdate(BaseModel):
+    """Request to update a conversation."""
+    title: Optional[str] = None
+    domain: Optional[str] = None
+    messages: Optional[List[MessageItem]] = None
+
+
+class ConversationSummary(BaseModel):
+    """Summary of a conversation for list view."""
+    id: str
+    title: str
+    domain: str
+    message_count: int
+    created_at: str
+    updated_at: str
+
+
+class ConversationDetail(BaseModel):
+    """Full conversation with messages."""
+    id: str
+    title: str
+    domain: str
+    messages: List[MessageItem]
+    created_at: str
+    updated_at: str
+
+
+@router.get("/", response_model=List[ConversationSummary])
+async def list_conversations():
+    """List all conversations, newest first."""
+    r = await get_redis()
+    conv_ids = await r.lrange(CONV_LIST_KEY, 0, -1)
+
+    conversations = []
+    for conv_id in conv_ids:
+        data = await r.get(f"{CONV_PREFIX}{conv_id}")
+        if data:
+            conv = json.loads(data)
+            conversations.append(ConversationSummary(
+                id=conv["id"],
+                title=conv["title"],
+                domain=conv["domain"],
+                message_count=len(conv.get("messages", [])),
+                created_at=conv["created_at"],
+                updated_at=conv["updated_at"],
+            ))
+
+    return conversations
+
+
+@router.post("/", response_model=ConversationDetail, status_code=201)
+async def create_conversation(req: ConversationCreate):
+    """Create a new conversation."""
+    r = await get_redis()
+    conv_id = str(uuid.uuid4())
+    now = datetime.utcnow().isoformat() + "Z"
+
+    conv = {
+        "id": conv_id,
+        "title": req.title or "新对话",
+        "domain": req.domain,
+        "messages": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    await r.set(f"{CONV_PREFIX}{conv_id}", json.dumps(conv, ensure_ascii=False))
+    await r.lpush(CONV_LIST_KEY, conv_id)
+
+    return ConversationDetail(**conv)
+
+
+@router.get("/{conv_id}", response_model=ConversationDetail)
+async def get_conversation(conv_id: str):
+    """Get a conversation by ID."""
+    r = await get_redis()
+    data = await r.get(f"{CONV_PREFIX}{conv_id}")
+    if not data:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    conv = json.loads(data)
+    return ConversationDetail(**conv)
+
+
+@router.put("/{conv_id}", response_model=ConversationDetail)
+async def update_conversation(conv_id: str, req: ConversationUpdate):
+    """Update a conversation (title, domain, or messages)."""
+    r = await get_redis()
+    data = await r.get(f"{CONV_PREFIX}{conv_id}")
+    if not data:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    conv = json.loads(data)
+
+    if req.title is not None:
+        conv["title"] = req.title
+    if req.domain is not None:
+        conv["domain"] = req.domain
+    if req.messages is not None:
+        conv["messages"] = [m.model_dump() for m in req.messages]
+
+    conv["updated_at"] = datetime.utcnow().isoformat() + "Z"
+
+    await r.set(f"{CONV_PREFIX}{conv_id}", json.dumps(conv, ensure_ascii=False))
+
+    return ConversationDetail(**conv)
+
+
+@router.delete("/{conv_id}", status_code=204)
+async def delete_conversation(conv_id: str):
+    """Delete a conversation."""
+    r = await get_redis()
+    deleted = await r.delete(f"{CONV_PREFIX}{conv_id}")
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    await r.lrem(CONV_LIST_KEY, 0, conv_id)
+    return None


### PR DESCRIPTION
## 概述 / Summary

实现对话历史的持久化存储与管理功能，使用 Redis 作为后端存储。

Implements conversation history persistence and management using Redis as the backend store.

Closes #16

---

## 变更内容 / Changes

### 后端 / Backend
- **新增** `server/api/v1/conversations.py` — Redis 持久化的对话 CRUD API
  - `GET /api/v1/conversations/` — 列出所有对话
  - `POST /api/v1/conversations/` — 创建新对话
  - `GET /api/v1/conversations/{id}` — 获取对话详情
  - `PUT /api/v1/conversations/{id}` — 更新对话（标题、消息等）
  - `DELETE /api/v1/conversations/{id}` — 删除对话
- **修改** `server/api/v1/__init__.py` — 注册 conversations 路由
- **修改** `pyproject.toml` — 添加 `redis>=5.0.0` 依赖

### 前端 / Frontend
- **新增** `ConversationSidebar.tsx` — 对话历史侧边栏组件
  - 显示对话列表，支持悬停删除
  - 相对时间格式化（刚刚/分钟前/小时前/天前）
  - 新建对话按钮
- **修改** `ChatPage.tsx` — 集成对话持久化逻辑
  - 每次助手回复后自动保存对话
  - 加载/切换/删除历史对话
  - 响应式布局：桌面端显示侧边栏

---

## 测试 / Testing

- [x] Redis 连通性测试通过
- [x] CRUD API 全部端点测试通过（200/201/204）
- [x] 通过 nginx 代理访问正常
- [x] Docker Compose 全部 5 个容器运行正常